### PR TITLE
테스트용: H2, 인메모리 DB

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,6 +7,7 @@ logging:
 
 spring:
   application.name: test-data
+  datasource.url: jdbc:h2:mem:testdb
   jpa:
     open-in-view: false
     defer-datasource-initialization: true
@@ -15,3 +16,9 @@ spring:
     properties:
       hibernate.format_sql: true
   sql.init.mode: always
+
+---
+
+spring:
+  config.activate.on-profile: test
+  datasource.url: jdbc:h2:mem:testdb;MODE=MySQL;DATABASE_TO_LOWER=TRUE


### PR DESCRIPTION
이 작업은 H2 DB를 사용하도록 스프링 부트 프로퍼티를 추가한다.
또한 테스트 프로파일을 별도 마련하여 mysql 호환성 모드로도 h2를 동작시킬 수 있도록 환경을 준비한다.

This closes #39 