### PR TITLE
[테스트 데이터 생성기] CH 03. CLIP 08. 로직 구현: 개인 스키마 정보 읽어들이기

### DIFF
--- a/src/main/java/uno/fastcampus/testdata/controller/TableSchemaController.java
+++ b/src/main/java/uno/fastcampus/testdata/controller/TableSchemaController.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,8 +20,9 @@ import uno.fastcampus.testdata.dto.request.TableSchemaRequest;
 import uno.fastcampus.testdata.dto.response.SchemaFieldResponse;
 import uno.fastcampus.testdata.dto.response.SimpleTableSchemaResponse;
 import uno.fastcampus.testdata.dto.response.TableSchemaResponse;
+import uno.fastcampus.testdata.dto.security.GithubUser;
+import uno.fastcampus.testdata.service.TableSchemaService;
 
-import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 
@@ -28,6 +30,7 @@ import java.util.List;
 @Controller
 public class TableSchemaController {
 
+    private final TableSchemaService tableSchemaService;
     private final ObjectMapper mapper;
 
     @GetMapping("/table-schema")
@@ -57,8 +60,14 @@ public class TableSchemaController {
     }
 
     @GetMapping("/table-schema/my-schemas")
-    public String mySchemas(Model model) {
-        var tableSchemas = mySampleSchemas();
+    public String mySchemas(
+            @AuthenticationPrincipal GithubUser githubUser,
+            Model model
+    ) {
+        List<SimpleTableSchemaResponse> tableSchemas = tableSchemaService.loadMySchemas(githubUser.id())
+                .stream()
+                .map(SimpleTableSchemaResponse::fromDto)
+                .toList();
 
         model.addAttribute("tableSchemas", tableSchemas);
 
@@ -89,14 +98,6 @@ public class TableSchemaController {
                         new SchemaFieldResponse("age", MockDataType.NUMBER, 3, 20, null, null),
                         new SchemaFieldResponse("my_car", MockDataType.CAR, 4, 50, null, null)
                 )
-        );
-    }
-
-    private static List<SimpleTableSchemaResponse> mySampleSchemas() {
-        return List.of(
-                new SimpleTableSchemaResponse("schema_name1", "Uno", LocalDate.of(2024, 1, 1).atStartOfDay()),
-                new SimpleTableSchemaResponse("schema_name2", "Uno", LocalDate.of(2024, 2, 2).atStartOfDay()),
-                new SimpleTableSchemaResponse("schema_name3", "Uno", LocalDate.of(2024, 3, 3).atStartOfDay())
         );
     }
 

--- a/src/main/java/uno/fastcampus/testdata/service/TableSchemaService.java
+++ b/src/main/java/uno/fastcampus/testdata/service/TableSchemaService.java
@@ -1,0 +1,33 @@
+package uno.fastcampus.testdata.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import uno.fastcampus.testdata.dto.TableSchemaDto;
+import uno.fastcampus.testdata.repository.TableSchemaRepository;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class TableSchemaService {
+
+    private final TableSchemaRepository tableSchemaRepository;
+
+
+    @Transactional(readOnly = true)
+    public List<TableSchemaDto> loadMySchemas(String userId) {
+        return loadMySchemas(userId, Pageable.unpaged()).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<TableSchemaDto> loadMySchemas(String userId, Pageable pageable) {
+        return tableSchemaRepository.findByUserId(userId, pageable)
+                .map(TableSchemaDto::fromEntity);
+    }
+
+
+}

--- a/src/test/java/uno/fastcampus/testdata/service/TableSchemaServiceTest.java
+++ b/src/test/java/uno/fastcampus/testdata/service/TableSchemaServiceTest.java
@@ -1,0 +1,52 @@
+package uno.fastcampus.testdata.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import uno.fastcampus.testdata.domain.TableSchema;
+import uno.fastcampus.testdata.dto.TableSchemaDto;
+import uno.fastcampus.testdata.repository.TableSchemaRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("[Service] 테이블 스키마 서비스 테스트")
+@ExtendWith(MockitoExtension.class)
+class TableSchemaServiceTest {
+
+    @InjectMocks private TableSchemaService sut;
+
+    @Mock private TableSchemaRepository tableSchemaRepository;
+
+
+    @DisplayName("사용자 ID가 주어지면, 테이블 스키마 목록을 반환한다.")
+    @Test
+    void givenUserId_whenLoadingMySchemas_thenReturnsTableSchemaList() {
+        // Given
+        String userId = "userId";
+        given(tableSchemaRepository.findByUserId(userId, Pageable.unpaged())).willReturn(new PageImpl<>(List.of(
+                TableSchema.of("table1", userId),
+                TableSchema.of("table2", userId),
+                TableSchema.of("table3", userId)
+        )));
+
+        // When
+        List<TableSchemaDto> result = sut.loadMySchemas(userId);
+
+        // Then
+        assertThat(result)
+                .hasSize(3)
+                .extracting("schemaName")
+                .containsExactly("table1", "table2", "table3");
+        then(tableSchemaRepository).should().findByUserId(userId, Pageable.unpaged());
+    }
+
+}


### PR DESCRIPTION
이 작업은 내 스키마 목록을 읽어들이는 실제 비즈니스 로직을 구현하여 컨트롤러 api에 기능으로 연결짓는다.

This closes #25 