### PR TITLE
[테스트 데이터 생성기] CH 03. CLIP 08. 로직 구현: 개인 스키마 정보 읽어들이기 2

### DIFF
--- a/src/main/java/uno/fastcampus/testdata/controller/TableSchemaController.java
+++ b/src/main/java/uno/fastcampus/testdata/controller/TableSchemaController.java
@@ -35,10 +35,13 @@ public class TableSchemaController {
 
     @GetMapping("/table-schema")
     public String tableSchema(
+            @AuthenticationPrincipal GithubUser githubUser,
             @RequestParam(required = false) String schemaName,
             Model model
     ) {
-        var tableSchema = defaultTableSchema(schemaName);
+        TableSchemaResponse tableSchema = (githubUser != null && schemaName != null) ?
+                TableSchemaResponse.fromDto(tableSchemaService.loadMySchema(githubUser.id(), schemaName)) :
+                defaultTableSchema(schemaName);
 
         model.addAttribute("tableSchema", tableSchema);
         model.addAttribute("mockDataTypes", MockDataType.toObjects());
@@ -46,8 +49,6 @@ public class TableSchemaController {
 
         return "table-schema";
     }
-
-
 
     @PostMapping("/table-schema")
     public String createOrUpdateTableSchema(

--- a/src/main/java/uno/fastcampus/testdata/service/TableSchemaService.java
+++ b/src/main/java/uno/fastcampus/testdata/service/TableSchemaService.java
@@ -1,5 +1,6 @@
 package uno.fastcampus.testdata.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -29,5 +30,11 @@ public class TableSchemaService {
                 .map(TableSchemaDto::fromEntity);
     }
 
+    @Transactional(readOnly = true)
+    public TableSchemaDto loadMySchema(String userId, String schemaName) {
+        return tableSchemaRepository.findByUserIdAndSchemaName(userId, schemaName)
+                .map(TableSchemaDto::fromEntity)
+                .orElseThrow(() -> new EntityNotFoundException("테이블 스키마가 없습니다 - userId: " + userId + ", schemaName: " + schemaName));
+    }
 
 }

--- a/src/test/java/uno/fastcampus/testdata/controller/TableSchemaControllerTest.java
+++ b/src/test/java/uno/fastcampus/testdata/controller/TableSchemaControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import uno.fastcampus.testdata.config.SecurityConfig;
 import uno.fastcampus.testdata.domain.constant.ExportFileType;
 import uno.fastcampus.testdata.domain.constant.MockDataType;
+import uno.fastcampus.testdata.dto.TableSchemaDto;
 import uno.fastcampus.testdata.dto.request.SchemaFieldRequest;
 import uno.fastcampus.testdata.dto.request.TableSchemaExportRequest;
 import uno.fastcampus.testdata.dto.request.TableSchemaRequest;
@@ -21,6 +22,7 @@ import uno.fastcampus.testdata.service.TableSchemaService;
 import uno.fastcampus.testdata.util.FormDataEncoder;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
@@ -55,6 +57,7 @@ class TableSchemaControllerTest {
                 .andExpect(model().attributeExists("mockDataTypes"))
                 .andExpect(model().attributeExists("fileTypes"))
                 .andExpect(view().name("table-schema"));
+        then(tableSchemaService).shouldHaveNoInteractions();
     }
 
     @DisplayName("[GET] 테이블 스키마 조회, 로그인 + 특정 테이블 스키마 (정상)")
@@ -63,6 +66,7 @@ class TableSchemaControllerTest {
         // Given
         var githubUser = new GithubUser("test-id", "test-name", "test@email.com");
         var schemaName = "test_schema";
+        given(tableSchemaService.loadMySchema(githubUser.id(), schemaName)).willReturn(TableSchemaDto.of(schemaName, githubUser.id(), null, Set.of()));
 
         // When & Then
         mvc.perform(
@@ -78,6 +82,7 @@ class TableSchemaControllerTest {
                 .andExpect(model().attributeExists("fileTypes"))
                 .andExpect(content().string(containsString(schemaName))) // html 전체 검사하므로 정확하지 않은 테스트 방식
                 .andExpect(view().name("table-schema"));
+        then(tableSchemaService).should().loadMySchema(githubUser.id(), schemaName);
     }
 
     @DisplayName("[POST] 테이블 스키마 생성, 변경 (정상)")


### PR DESCRIPTION
이 pr은 지난 #66 작업에 이어서 회원 스키마 테이블 단건 조회를 구현하고 컨트롤러와 연결한다.

This closes #22 