### PR TITLE
[테스트 데이터 생성기] CH 03. CLIP 11. 로직 구현: 개인 스키마 정보 삭제하기

### DIFF
--- a/src/main/java/uno/fastcampus/testdata/controller/TableSchemaController.java
+++ b/src/main/java/uno/fastcampus/testdata/controller/TableSchemaController.java
@@ -79,7 +79,12 @@ public class TableSchemaController {
     }
 
     @PostMapping("/table-schema/my-schemas/{schemaName}")
-    public String deleteMySchema(@PathVariable String schemaName) {
+    public String deleteMySchema(
+            @AuthenticationPrincipal GithubUser githubUser,
+            @PathVariable String schemaName
+    ) {
+        tableSchemaService.deleteTableSchema(githubUser.id(), schemaName);
+
         return "redirect:/table-schema/my-schemas";
     }
 

--- a/src/main/java/uno/fastcampus/testdata/service/TableSchemaService.java
+++ b/src/main/java/uno/fastcampus/testdata/service/TableSchemaService.java
@@ -45,4 +45,8 @@ public class TableSchemaService {
                 );
     }
 
+    public void deleteTableSchema(String userId, String schemaName) {
+        tableSchemaRepository.deleteByUserIdAndSchemaName(userId, schemaName);
+    }
+
 }

--- a/src/test/java/uno/fastcampus/testdata/controller/TableSchemaControllerTest.java
+++ b/src/test/java/uno/fastcampus/testdata/controller/TableSchemaControllerTest.java
@@ -149,6 +149,7 @@ class TableSchemaControllerTest {
         // Given
         var githubUser = new GithubUser("test-id", "test-name", "test@email.com");
         String schemaName = "test_schema";
+        willDoNothing().given(tableSchemaService).deleteTableSchema(githubUser.id(), schemaName);
 
         // When & Then
         mvc.perform(
@@ -158,6 +159,7 @@ class TableSchemaControllerTest {
         )
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("/table-schema/my-schemas"));
+        then(tableSchemaService).should().deleteTableSchema(githubUser.id(), schemaName);
     }
 
     @DisplayName("[GET] 테이블 스키마 파일 다운로드 (정상)")

--- a/src/test/java/uno/fastcampus/testdata/service/TableSchemaServiceTest.java
+++ b/src/test/java/uno/fastcampus/testdata/service/TableSchemaServiceTest.java
@@ -19,8 +19,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.*;
 
 @DisplayName("[Service] 테이블 스키마 서비스 테스트")
 @ExtendWith(MockitoExtension.class)
@@ -123,6 +122,21 @@ class TableSchemaServiceTest {
         // Then
         then(tableSchemaRepository).should().findByUserIdAndSchemaName(dto.userId(), dto.schemaName());
         then(tableSchemaRepository).should().save(dto.createEntity());
+    }
+
+    @DisplayName("사용자 ID와 스키마 이름이 주어지면, 테이블 스키마를 삭제한다.")
+    @Test
+    void givenUserIdAndSchemaName_whenDeleting_thenDeletesTableSchema() {
+        // Given
+        String userId = "userId";
+        String schemaName = "table1";
+        willDoNothing().given(tableSchemaRepository).deleteByUserIdAndSchemaName(userId, schemaName);
+
+        // When
+        sut.deleteTableSchema(userId, schemaName);
+
+        // Then
+        then(tableSchemaRepository).should().deleteByUserIdAndSchemaName(userId, schemaName);
     }
 
 }


### PR DESCRIPTION
이 작업은 테이블 스키마 삭제 기능을 구현하고, 컨트롤러에 기능을 연결한다.

This closes #28 