### PR TITLE
파일 이름을 테이블 스키마 이름과 파일 형식에 따라 변하게 설정하기

### DIFF
--- a/src/main/java/uno/fastcampus/testdata/controller/TableSchemaController.java
+++ b/src/main/java/uno/fastcampus/testdata/controller/TableSchemaController.java
@@ -90,9 +90,10 @@ public class TableSchemaController {
 
     @GetMapping("/table-schema/export")
     public ResponseEntity<String> exportTableSchema(TableSchemaExportRequest tableSchemaExportRequest) {
+        String filename = tableSchemaExportRequest.getSchemaName() + "." + tableSchemaExportRequest.getFileType().name().toLowerCase();
 
         return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=table-schema.txt")
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + filename)
                 .body(json(tableSchemaExportRequest)); // TODO: 나중에 데이터 바꿔야 함
     }
 

--- a/src/test/java/uno/fastcampus/testdata/controller/TableSchemaControllerTest.java
+++ b/src/test/java/uno/fastcampus/testdata/controller/TableSchemaControllerTest.java
@@ -169,7 +169,7 @@ class TableSchemaControllerTest {
         TableSchemaExportRequest request = TableSchemaExportRequest.of(
                 "test",
                 77,
-                ExportFileType.JSON,
+                ExportFileType.CSV,
                 List.of(
                         SchemaFieldRequest.of("id", MockDataType.ROW_NUMBER, 1, 0, null, null),
                         SchemaFieldRequest.of("name", MockDataType.STRING, 1, 0, "option", "well"),
@@ -182,7 +182,7 @@ class TableSchemaControllerTest {
         mvc.perform(get("/table-schema/export?" + queryParam))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
-                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=table-schema.txt"))
+                .andExpect(header().string(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=test.csv"))
                 .andExpect(content().json(mapper.writeValueAsString(request))); // TODO: 나중에 데이터 바꿔야 함
     }
 


### PR DESCRIPTION
이 작업은 파일 다운로드 시 파일명을 테이블 스키마 이름과 파일 형식으로 조립하여 이용자의 편의를 도모합니다.

This closes #71 